### PR TITLE
feat: add test data strategy section to generate-bdd-tests skill

### DIFF
--- a/.claude/skills/generate-bdd-tests/SKILL.md
+++ b/.claude/skills/generate-bdd-tests/SKILL.md
@@ -45,7 +45,7 @@ Check which feature file the resource belongs in:
 - **Multi-version resources** (both R5 + R4B): `multi-version-resource-crud.feature`
 - **Custom resources** (has generated class from codegen): `custom-resource-crud.feature`
 
-Also create the corresponding test data files if missing:
+Also create the corresponding test data files if missing (see **Test Data Strategy** section for naming conventions, content guidelines, and multi-file loading patterns):
 ```
 testdata/crud/{resource}.json              # baseline
 testdata/crud/{resource}-update.json       # update body
@@ -53,6 +53,7 @@ testdata/crud/{resource}-patch.json        # JSON Patch (if patch enabled)
 testdata/crud/{resource}-minimum-set.json  # mandatory fields only
 testdata/crud/{resource}-common-set.json   # typical real-world payload
 testdata/crud/{resource}-maximum-set.json  # all supported fields
+testdata/crud/{resource}-invalid.json      # invalid body for 422 tests
 ```
 
 #### Search Gaps → Add to search feature files
@@ -131,6 +132,133 @@ Files modified:
 - ...
 ```
 
+## Test Data Strategy
+
+All FHIR resource request bodies live in external JSON files under `src/test/resources/testdata/`, loaded by `TestDataLoader`. **Never embed JSON resource bodies inline in step classes or feature files.**
+
+### Directory Structure
+
+```
+testdata/
+  crud/                           # CRUD lifecycle payloads
+    {resource}.json               # baseline (primary cross-resource Scenario Outline)
+    {resource}-update.json        # PUT update body
+    {resource}-patch.json         # JSON Patch document (RFC 6902) — only for PATCH-enabled resources
+    {resource}-minimum-set.json   # Profile variant: mandatory fields only
+    {resource}-common-set.json    # Profile variant: typical real-world payload
+    {resource}-maximum-set.json   # Profile variant: all supported fields
+    {resource}-invalid.json       # Invalid body for 422 tests
+  operations/                     # Operation input payloads
+    merge-parameters.json         # FHIR Parameters (composite: source + target inline)
+    validate-patient.json         # $validate input body
+    validate-patient-profile.json # $validate with profile
+  bundle/                         # Bundle payloads
+    batch-create.json             # FHIR Bundle (batch type)
+    transaction-create.json       # FHIR Bundle (transaction type)
+  setup/                          # Background/seed data for multi-resource scenarios
+    patient.json                  # Seed data for $everything setup
+    observation.json
+    condition.json
+  tenant/                         # Multi-tenancy test data
+    tenant-a-patient.json         # POST to tenant A
+    tenant-b-patient.json         # POST to tenant B
+```
+
+### File Naming Conventions
+
+| Purpose | File name pattern | Example |
+|---|---|---|
+| Default / baseline create | `{resource}.json` | `patient.json` |
+| Named data variant | `{resource}-{profile}.json` | `patient-minimum-set.json` |
+| Update body | `{resource}-update.json` | `patient-update.json` |
+| Patch document (RFC 6902) | `{resource}-patch.json` | `patient-patch.json` |
+| Invalid body (422 tests) | `{resource}-invalid.json` | `patient-invalid.json` |
+| Composite/multi-part | `{operation}-parameters.json` | `merge-parameters.json` |
+
+### TestDataLoader API
+
+```java
+// Load a single file (most common)
+String body = TestDataLoader.load("crud/patient.json");
+
+// Load a profile variant
+String body = TestDataLoader.load("crud/" + resourceType.toLowerCase() + "-" + profile + ".json");
+
+// Load multiple files for setup/teardown (Pattern 3)
+List<String> bodies = TestDataLoader.loadAll(
+    "crud/patient.json",
+    "crud/observation.json",
+    "crud/condition.json"
+);
+```
+
+### Four Multi-File Patterns
+
+When generating steps that need multiple JSON files, follow the correct pattern:
+
+**Pattern 1 — Sequential loads** (step makes multiple HTTP calls):
+```java
+// CRUD update: POST create body, then PUT update body
+String createBody = TestDataLoader.load("crud/" + resourceType.toLowerCase() + ".json");
+String updateBody = TestDataLoader.load("crud/" + resourceType.toLowerCase() + "-update.json");
+```
+Applies to: CRUD update, PATCH (resource body + patch document), tenant isolation (one POST per tenant).
+
+**Pattern 2 — Composite single request** (one HTTP call, body built from parts):
+Create a dedicated composite JSON file that is the full request payload. Do NOT merge files in Java.
+```java
+String body = TestDataLoader.load("operations/merge-parameters.json");
+```
+Applies to: `$merge` (Parameters), batch/transaction bundles.
+
+**Pattern 3 — Setup/teardown data** (seed resources before the scenario's actual step):
+```java
+List<String> bodies = TestDataLoader.loadAll("crud/patient.json", "crud/observation.json");
+bodies.forEach(body -> given().body(body).post("/fhir/r5/..."));
+```
+Applies to: `$everything`, search count assertions, linked-resource scenarios.
+
+**Pattern 4 — Data variants** (multiple payloads for the same operation):
+Use profile labels in Gherkin (Option A), resolved to files by naming convention:
+```gherkin
+Scenario Outline: Resource create - data variants
+  When I create a "<profile>" <resourceType>
+  Then the response status is 201
+  Examples:
+    | resourceType | profile      |
+    | patient      | minimum-set  |
+    | patient      | common-set   |
+    | patient      | maximum-set  |
+    | observation  | minimum-set  |
+```
+Step class resolves `profile` to a file path — no branching:
+```java
+@When("I create a {string} {word}")
+public void createResourceVariant(String profile, String resourceType) throws IOException {
+    String body = TestDataLoader.load("crud/" + resourceType.toLowerCase() + "-" + profile + ".json");
+}
+```
+Adding a new variant = one new `Examples` row + one new JSON file. Zero Java changes.
+
+### Inline vs External File Rule
+
+| Use inline | Use external file |
+|---|---|
+| Short scalar values (`"active"`, `"Smith"`) | Any request body (FHIR resource JSON) |
+| URL query parameter strings (`?family=Smith`) | Operation input payloads (`$validate`, `$merge`) |
+| Response field assertions (`"resourceType": "Patient"`) | Tenant fixture payloads |
+| Error message fragments | Anything > ~5 tokens or subject to change independently |
+
+### When Generating New Test Data Files
+
+1. Always create valid FHIR JSON that matches the resource's StructureDefinition
+2. For **minimum-set**: include only mandatory fields (e.g., Patient needs `name` + `gender`)
+3. For **common-set**: add typical clinical fields (e.g., Patient + `identifier`, `birthDate`, `telecom`)
+4. For **maximum-set**: populate all fields the server supports
+5. Use placeholder IDs and references — the server assigns real IDs on create
+6. For **patch** files: use RFC 6902 JSON Patch format (`[{"op": "replace", "path": "/...", "value": ...}]`)
+7. For **invalid** files: include a structural error that triggers 422 (e.g., missing required field, wrong type)
+
 ## Project Structure Reference
 
 ```
@@ -162,7 +290,11 @@ fhir4java-server/src/test/
     │   ├── conformance/    # Conformance resource tests
     │   └── tenancy/        # Multi-tenancy tests
     └── testdata/
-        └── crud/           # JSON test data (62 files)
+        ├── crud/           # CRUD lifecycle payloads (62+ files)
+        ├── operations/     # Operation input payloads ($merge, $validate)
+        ├── bundle/         # Bundle payloads (batch, transaction)
+        ├── setup/          # Seed data for multi-resource scenarios
+        └── tenant/         # Multi-tenancy test data
 ```
 
 ## Resource Configuration Reference


### PR DESCRIPTION
Add comprehensive test data guidance from Section 9 Q3 of the BDD implementation plan: directory structure, file naming conventions, TestDataLoader API, four multi-file loading patterns (sequential, composite, setup/teardown, data variants), inline vs external file rule, and content guidelines for generating new test data files.

https://claude.ai/code/session_01Tu7NmtPY7aVRJGDVg39fCt