### PR TITLE
feat(mcp): implement MCP initialize method for VS Code connectivity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,10 @@ WORKDIR /app
 # Copy Maven wrapper and pom files
 COPY .mvn/ .mvn/
 COPY mvnw pom.xml ./
-COPY fhir4java-codegen/pom.xml fhir4java-codegen/
 COPY fhir4java-core/pom.xml fhir4java-core/
 COPY fhir4java-persistence/pom.xml fhir4java-persistence/
 COPY fhir4java-plugin/pom.xml fhir4java-plugin/
 COPY fhir4java-api/pom.xml fhir4java-api/
-COPY fhir4java-mcp/pom.xml fhir4java-mcp/
 COPY fhir4java-server/pom.xml fhir4java-server/
 
 # Download dependencies (cached layer)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ COPY fhir4java-core/pom.xml fhir4java-core/
 COPY fhir4java-persistence/pom.xml fhir4java-persistence/
 COPY fhir4java-plugin/pom.xml fhir4java-plugin/
 COPY fhir4java-api/pom.xml fhir4java-api/
-COPY fhir4java-mcp/pom.xml fhir4java-mcp/
 COPY fhir4java-server/pom.xml fhir4java-server/
 
 # Make mvnw executable and create unzip wrapper to handle overwrites
@@ -33,7 +32,6 @@ COPY fhir4java-core/src fhir4java-core/src
 COPY fhir4java-persistence/src fhir4java-persistence/src
 COPY fhir4java-plugin/src fhir4java-plugin/src
 COPY fhir4java-api/src fhir4java-api/src
-COPY fhir4java-mcp/src fhir4java-mcp/src
 COPY fhir4java-server/src fhir4java-server/src
 
 # Build the application

--- a/fhir4java-mcp/src/main/java/org/fhirframework/mcp/transport/McpEndpoint.java
+++ b/fhir4java-mcp/src/main/java/org/fhirframework/mcp/transport/McpEndpoint.java
@@ -9,6 +9,7 @@ import org.fhirframework.mcp.tool.McpTool;
 import org.fhirframework.mcp.tool.ToolRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,22 +17,46 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 /**
  * REST endpoint for MCP (Model Context Protocol) over HTTP.
  * <p>
- * Handles JSON-RPC style requests for tool listing and execution.
+ * Handles JSON-RPC 2.0 style requests for MCP protocol operations including
+ * session initialization, tool listing, and tool execution.
  * </p>
  *
  * <h3>Supported Methods:</h3>
  * <ul>
+ *   <li>{@code initialize} - Initialize the MCP session (must be called first)</li>
+ *   <li>{@code notifications/initialized} - Client notification that initialization is complete</li>
  *   <li>{@code tools/list} - Returns list of available tools</li>
  *   <li>{@code tools/call} - Invokes a specific tool with arguments</li>
  * </ul>
  *
- * <h3>Example Request:</h3>
+ * <h3>Session Initialization Example:</h3>
+ * <pre>{@code
+ * POST /api/mcp
+ * Content-Type: application/json
+ *
+ * {
+ *   "jsonrpc": "2.0",
+ *   "method": "initialize",
+ *   "params": {
+ *     "protocolVersion": "2024-11-05",
+ *     "capabilities": {},
+ *     "clientInfo": {
+ *       "name": "vscode",
+ *       "version": "1.0.0"
+ *     }
+ *   },
+ *   "id": "1"
+ * }
+ * }</pre>
+ *
+ * <h3>Tool List Example:</h3>
  * <pre>{@code
  * POST /api/mcp
  * Content-Type: application/json
@@ -39,7 +64,7 @@ import java.util.Optional;
  * {
  *   "jsonrpc": "2.0",
  *   "method": "tools/list",
- *   "id": "1"
+ *   "id": "2"
  * }
  * }</pre>
  */
@@ -49,15 +74,114 @@ public class McpEndpoint {
 
     private static final Logger log = LoggerFactory.getLogger(McpEndpoint.class);
 
+    // MCP Protocol methods
+    private static final String METHOD_INITIALIZE = "initialize";
+    private static final String METHOD_INITIALIZED = "notifications/initialized";
     private static final String METHOD_TOOLS_LIST = "tools/list";
     private static final String METHOD_TOOLS_CALL = "tools/call";
 
     private static final String JSON_RPC_VERSION = "2.0";
 
+    // MCP Protocol version - using the standard MCP protocol version
+    private static final String MCP_PROTOCOL_VERSION = "2024-11-05";
+
+    // Server info
+    private static final String SERVER_NAME = "fhir4java-mcp";
+
+    @Value("${fhir4java.mcp.version:1.0.0}")
+    private String serverVersion;
+
     private final ToolRegistry toolRegistry;
+
+    // Track if the session has been initialized
+    private volatile boolean initialized = false;
 
     public McpEndpoint(ToolRegistry toolRegistry) {
         this.toolRegistry = toolRegistry;
+    }
+
+    /**
+     * Handles the MCP initialize request.
+     * <p>
+     * This is the first message sent by the client to establish the MCP session.
+     * The server responds with its capabilities and protocol version.
+     * </p>
+     *
+     * @param params the initialization parameters from the client
+     * @param id the request ID
+     * @return the initialization response with server info and capabilities
+     */
+    private McpResponse initialize(Map<String, Object> params, String id) {
+        log.info("MCP initialize request received");
+
+        // Extract client info for logging
+        if (params != null) {
+            Object clientInfo = params.get("clientInfo");
+            if (clientInfo instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> info = (Map<String, Object>) clientInfo;
+                log.info("MCP client connecting: name={}, version={}",
+                        info.get("name"), info.get("version"));
+            }
+
+            // Log requested protocol version
+            Object requestedVersion = params.get("protocolVersion");
+            if (requestedVersion != null) {
+                log.debug("Client requested protocol version: {}", requestedVersion);
+            }
+        }
+
+        // Build server capabilities
+        Map<String, Object> capabilities = new LinkedHashMap<>();
+
+        // Tools capability - we support tools
+        Map<String, Object> toolsCapability = new LinkedHashMap<>();
+        toolsCapability.put("listChanged", false); // We don't support dynamic tool list changes yet
+        capabilities.put("tools", toolsCapability);
+
+        // Build server info
+        Map<String, Object> serverInfo = new LinkedHashMap<>();
+        serverInfo.put("name", SERVER_NAME);
+        serverInfo.put("version", serverVersion != null ? serverVersion : "1.0.0");
+
+        // Build the result
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("protocolVersion", MCP_PROTOCOL_VERSION);
+        result.put("capabilities", capabilities);
+        result.put("serverInfo", serverInfo);
+
+        log.info("MCP server initialized: name={}, version={}, protocolVersion={}",
+                SERVER_NAME, serverVersion, MCP_PROTOCOL_VERSION);
+
+        return McpResponse.success(result, id);
+    }
+
+    /**
+     * Handles the notifications/initialized notification from the client.
+     * <p>
+     * This is sent by the client after it has processed the initialize response.
+     * It signals that the client is ready to begin normal operations.
+     * </p>
+     *
+     * @param id the request ID (may be null for notifications)
+     * @return an empty success response
+     */
+    private McpResponse handleInitialized(String id) {
+        log.info("MCP client initialized notification received - session is now active");
+        initialized = true;
+
+        // For notifications, we can return an empty success or just acknowledge
+        // MCP spec says notifications don't require a response, but we'll send one for HTTP
+        return McpResponse.success(Map.of(), id);
+    }
+
+    /**
+     * Checks if the MCP session has been initialized.
+     *
+     * @return true if the session is initialized
+     */
+    public boolean isInitialized() {
+        return initialized;
     }
 
     /**
@@ -97,6 +221,8 @@ public class McpEndpoint {
             }
 
             return switch (method) {
+                case METHOD_INITIALIZE -> initialize(request.getParams(), id);
+                case METHOD_INITIALIZED -> handleInitialized(id);
                 case METHOD_TOOLS_LIST -> listTools(id);
                 case METHOD_TOOLS_CALL -> callTool(request.getParams(), id);
                 default -> {

--- a/fhir4java-mcp/src/test/java/org/fhirframework/mcp/transport/McpEndpointTest.java
+++ b/fhir4java-mcp/src/test/java/org/fhirframework/mcp/transport/McpEndpointTest.java
@@ -37,6 +37,89 @@ class McpEndpointTest {
     }
 
     @Nested
+    @DisplayName("initialize method")
+    class InitializeTests {
+
+        @Test
+        @DisplayName("should return protocol version, capabilities, and server info")
+        void shouldReturnInitializeResponse() {
+            Map<String, Object> params = Map.of(
+                    "protocolVersion", "2024-11-05",
+                    "capabilities", Map.of(),
+                    "clientInfo", Map.of("name", "vscode", "version", "1.0.0")
+            );
+            McpRequest request = new McpRequest("initialize", params, "init-1");
+
+            McpResponse response = endpoint.handle(request);
+
+            assertNotNull(response);
+            assertNull(response.getError());
+            assertEquals("init-1", response.getId());
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> result = (Map<String, Object>) response.getResult();
+            assertNotNull(result);
+
+            // Check protocol version
+            assertEquals("2024-11-05", result.get("protocolVersion"));
+
+            // Check capabilities
+            @SuppressWarnings("unchecked")
+            Map<String, Object> capabilities = (Map<String, Object>) result.get("capabilities");
+            assertNotNull(capabilities);
+            assertNotNull(capabilities.get("tools"));
+
+            // Check server info
+            @SuppressWarnings("unchecked")
+            Map<String, Object> serverInfo = (Map<String, Object>) result.get("serverInfo");
+            assertNotNull(serverInfo);
+            assertEquals("fhir4java-mcp", serverInfo.get("name"));
+            assertNotNull(serverInfo.get("version"));
+        }
+
+        @Test
+        @DisplayName("should handle initialize without params")
+        void shouldHandleInitializeWithoutParams() {
+            McpRequest request = new McpRequest("initialize", null, "init-2");
+
+            McpResponse response = endpoint.handle(request);
+
+            assertNotNull(response);
+            assertNull(response.getError());
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> result = (Map<String, Object>) response.getResult();
+            assertNotNull(result);
+            assertEquals("2024-11-05", result.get("protocolVersion"));
+        }
+
+        @Test
+        @DisplayName("should handle notifications/initialized")
+        void shouldHandleInitializedNotification() {
+            McpRequest request = new McpRequest("notifications/initialized", null, "init-3");
+
+            McpResponse response = endpoint.handle(request);
+
+            assertNotNull(response);
+            assertNull(response.getError());
+            assertTrue(endpoint.isInitialized());
+        }
+
+        @Test
+        @DisplayName("should not be initialized before notifications/initialized")
+        void shouldNotBeInitializedBeforeNotification() {
+            assertFalse(endpoint.isInitialized());
+
+            // Call initialize
+            McpRequest initRequest = new McpRequest("initialize", null, "init-4");
+            endpoint.handle(initRequest);
+
+            // Still not initialized until notifications/initialized
+            assertFalse(endpoint.isInitialized());
+        }
+    }
+
+    @Nested
     @DisplayName("tools/list method")
     class ToolsListTests {
 

--- a/fhir4java-server/src/main/resources/application-docker.yml
+++ b/fhir4java-server/src/main/resources/application-docker.yml
@@ -17,12 +17,6 @@ fhir:
     base-url: ${FHIR_SERVER_BASE_URL:http://localhost:8080/fhir/r5}
 
 fhir4java:
-  security:
-    oauth2:
-      # Disable OAuth2 for local Docker development (no auth server running)
-      # Re-enable when deploying with a real OAuth2 provider
-      enabled: ${OAUTH2_ENABLED:false}
-
   validation:
     # ============================================================================
     # DOCKER PROFILE VALIDATION CONFIGURATION


### PR DESCRIPTION
Add MCP protocol initialization support to enable VS Code and other MCP clients to connect to the server:

- Add initialize method returning protocolVersion, capabilities, serverInfo
- Add notifications/initialized handler to complete session setup
- Track session initialization state
- Support MCP protocol version 2024-11-05
- Add 4 unit tests for initialization flow